### PR TITLE
Adding buddybuild status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # SwiftSpace
+
+[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=565760eb28898101003ae8b3&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/565760eb28898101003ae8b3/build/latest)
+
 Gyroscope Driven Drawing in 3D Space
  
 Companion project to: http://flexmonkey.blogspot.co.uk/2015/08/coremotion-controlled-3d-sketching-on.html


### PR DESCRIPTION
We really liked SwiftSpace and wanted to offer you a free continuous integration system [(buddybuild)](buddybuild.com) to make sure that your app always works!

If this sounds like something that may be helpful, setup is really simple and we've already taken most of the steps for you…[here](https://dashboard.buddybuild.com/apps/565760eb28898101003ae8b3/build/latest) are the builds we've completed forSwiftSpace so far.

![screen shot 2015-11-26 at 11 56 04 am](https://cloud.githubusercontent.com/assets/13876667/11429999/c058c418-9434-11e5-808c-f5aa832fe3a7.png)

To configure your builds and to to make sure we kick off a new build with every commit you make, simply login [here] (dashboard.buddybuild.com).

Finally, if you’d like to know the latest build status of your app directly from your repo page, we offer small status badges - like the one seen on the [flappyswift](https://github.com/fullstackio/FlappySwift) repo.

To help add these, we created this pull request by adding a couple of lines to the readme.

If you have any questions or would like to learn more about buddybuild, feel free to email team@buddybuild.com directly or use the Intercom button on the website.